### PR TITLE
Create an installer script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Python stuff
+*.pyc
+*.pyo
+
+# Setuptools build dir
+/build

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 
 # Setuptools build dir
 /build
+/dist
+*.egg-info

--- a/rsatool.py
+++ b/rsatool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 import base64, fractions, optparse, random
 import gmpy
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+
+from setuptools import setup
 
 setup(name='rsatool',
         version='1.0',
@@ -8,6 +9,6 @@ setup(name='rsatool',
         author='Joerie de Gram',
         author_email='j.de.gram@gmail.com',
         url='https://github.com/ius/rsatool',
-        requires=['gmpy', 'pyasn1'],
+        install_requires=['gmpy', 'pyasn1'],
         scripts=['rsatool.py']
         )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+
+setup(name='rsatool',
+        version='1.0',
+        description='rsatool can be used to calculate RSA and RSA-CRT parameters',
+        author='Joerie de Gram',
+        author_email='j.de.gram@gmail.com',
+        url='https://github.com/ius/rsatool',
+        requires=['gmpy', 'pyasn1'],
+        scripts=['rsatool.py']
+        )


### PR DESCRIPTION
This PR adds an installer script and changes the shebang from `/usr/bin/python2` to `/usr/bin/env python2` for systems where python may be installed in other locations, e.g. FreeBSD / OSX.
