### PR TITLE
Correct Euler's totient function in all cases

### DIFF
--- a/rsatool.py
+++ b/rsatool.py
@@ -79,7 +79,11 @@ class RSA:
     def _calc_values(self):
         self.n = self.p * self.q
 
-        phi = (self.p - 1) * (self.q - 1)
+        if self.p != self.q:
+            phi = (self.p - 1) * (self.q - 1)
+        else:
+            phi = (self.p ** 2) - self.p
+
         self.d = gmpy.invert(self.e, phi)
 
         # CRT-RSA precomputation


### PR DESCRIPTION
It's obviously never good to have *p == q*, but when this happens we need
to compute the correct version of Euler's totient function. In fact when
*phi(p * q) == phi(p) * phi(q)* only when p and q are coprime.

*phi(p<sup>k</sup>) = p<sup>k</sup> - p<sup>k-1</sup>*

So when *p == q* we have *phi(p<sup>2</sup>) = p<sup>2</sup> - p* .