### PR TITLE
Fix issues with run on Windows python 2.7.13 install

### DIFF
--- a/rsatool.py
+++ b/rsatool.py
@@ -9,7 +9,8 @@ except ImportError as e:
         raise e
 
 from pyasn1.codec.der import encoder
-from pyasn1.type.univ import *
+from pyasn1.type import univ
+from pyasn1.type.univ import Sequence
 
 PEM_TEMPLATE = '-----BEGIN RSA PRIVATE KEY-----\n%s-----END RSA PRIVATE KEY-----\n'
 DEFAULT_EXP = 65537
@@ -101,10 +102,10 @@ class RSA:
         """
         Return parameters as OpenSSL compatible DER encoded key
         """
-        seq = Sequence()
+        seq = univ.SequenceOf(componentType=univ.Integer())
 
         for x in [0, self.n, self.e, self.d, self.p, self.q, self.dP, self.dQ, self.qInv]:
-            seq.setComponentByPosition(len(seq), Integer(x))
+            seq.append(univ.Integer(x))
 
         return encoder.encode(seq)
 

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@ setup(name='rsatool',
         author='Joerie de Gram',
         author_email='j.de.gram@gmail.com',
         url='https://github.com/ius/rsatool',
-        install_requires=['gmpy', 'pyasn1'],
+        install_requires=['gmpy2', 'pyasn1'],
         scripts=['rsatool.py']
         )


### PR DESCRIPTION
Thanks for sharing this project!

I noticed two small issues when attempting to use on Windows with python 2.7.13 installation:

* Pip could not find gmpy
** changed to use gmpy2 to resolve
* pyasn1 0.3.2 died with "tuple index out of range" in namedtype.py during encode step
** Modified to use SequenceOf(componentType=) to match pyasn1 unit tests

Hope this helps someone else!