### PR TITLE
Fix a small bug with the use of setComponentByPosition in pyasn1

### DIFF
--- a/rsatool.py
+++ b/rsatool.py
@@ -103,8 +103,8 @@ class RSA:
         """
         seq = Sequence()
 
-        for x in [0, self.n, self.e, self.d, self.p, self.q, self.dP, self.dQ, self.qInv]:
-            seq.setComponentByPosition(len(seq), Integer(x))
+        for i, x in enumerate([0, self.n, self.e, self.d, self.p, self.q, self.dP, self.dQ, self.qInv]):
+            seq.setComponentByPosition(i, Integer(x))
 
         return encoder.encode(seq)
 


### PR DESCRIPTION
I was using this great tool for a CTF, I wanted to generate the private key PEM file, given the RSA modulus and both public and private exponents. I ran the command and there was an error during the generation of the file, in the function setComponentByPosition. I checked the documentation and made a little modification that made the program work as expected for me.

I don't know what it's worth but I prefer to send it to you.
Thanks for the tool !