### PR TITLE
raise exception instead of ending in endless loop for invalid inputs

### DIFF
--- a/rsatool.py
+++ b/rsatool.py
@@ -37,6 +37,9 @@ def factor_modulus(n, d, e):
     t = (e * d - 1)
     s = 0
 
+    if 17 !=  gmpy.powmod(17, e*d, n):
+        raise ValueError("n, d, e don't match")
+
     while True:
         quotient, remainder = divmod(t, 2)
 


### PR DESCRIPTION
When feeding invalid d, e, n values (for example values not belonging to the same key) into rsatool it can get stuck in an endless loop trying to factor n.

My proposed patch avoids this by checking whether these values make sense. Essentially I'm trying to encrypt and decrypt a value and check the result, for a valid key this would always work, for an invalid key it raises an exception.

Alternatively one could put a limit on the loop starting with "while not found", however I find this the more elegant solution.