### PR TITLE
Use ValueError instead of nonexistent ArgumentError

### DIFF
--- a/rsatool.py
+++ b/rsatool.py
@@ -80,7 +80,7 @@ class RSA:
         elif n and d:
             self.p, self.q = factor_modulus(n, d, e)
         else:
-            raise ArgumentError('Either (p, q) or (n, d) must be provided')
+            raise ValueError('Either (p, q) or (n, d) must be provided')
 
         self._calc_values()
 


### PR DESCRIPTION
When called without proper parameters the RSA class will raise an ArgumentError. However there is no such error type in Python.

There is an ArgumentError in the argparse module, but I don't think that fits here, as this is for commandline parsing. I think a ValueError is the correct error type to raise.