### PR TITLE
change var name to avoid l

### DIFF
--- a/rsatool.py
+++ b/rsatool.py
@@ -122,8 +122,8 @@ class RSA:
     def _dumpvar(self, var):
         val = getattr(self, var)
 
-        def parts(s, l):
-            return '\n'.join([s[i:i + l] for i in range(0, len(s), l)])
+        def parts(s, x):
+            return '\n'.join([s[i:i + x] for i in range(0, len(s), x)])
 
         if len(str(val)) <= 40:
             print('%s = %d (%#x)\n' % (var, val, val))


### PR DESCRIPTION
pycodestyle warns about variables named "l" because it can easily be confused with 1 (rsatool.py:125:22: E741 ambiguous variable name 'l').

This now fixes all codingstyle issues reported by pycodestyle except line length. I have skipped changing those as it requires some quite invasive changes and line length changes are kinda controversial. So this should give no warnings with:
```
pycodestyle --ignore=E501 *.py
```

You may want to check this in a CI. Shall I open another PR adding a github action to regularly check the codingstyle?