### PR TITLE
Wrap after 64 chars according to PEM (RFC 7468) standard

### DIFF
--- a/rsatool.py
+++ b/rsatool.py
@@ -3,6 +3,7 @@ import base64
 import argparse
 import random
 import sys
+import textwrap
 
 import gmpy2
 
@@ -10,9 +11,9 @@ from pyasn1.codec.der import encoder
 from pyasn1.type.univ import Sequence, Integer
 
 PEM_TEMPLATE = (
-    b'-----BEGIN RSA PRIVATE KEY-----\n'
-    b'%s'
-    b'-----END RSA PRIVATE KEY-----'
+    '-----BEGIN RSA PRIVATE KEY-----\n'
+    '%s\n'
+    '-----END RSA PRIVATE KEY-----\n'
 )
 
 DEFAULT_EXP = 65537
@@ -103,7 +104,9 @@ class RSA:
         """
         Return OpenSSL-compatible PEM encoded key
         """
-        return PEM_TEMPLATE % base64.encodebytes(self.to_der())
+        b64 = base64.b64encode(self.to_der()).decode()
+        b64w = "\n".join(textwrap.wrap(b64, 64))
+        return (PEM_TEMPLATE % b64w).encode()
 
     def to_der(self):
         """


### PR DESCRIPTION
The current code creates PEM files with 76 chars per line due to the use of the python base64.encodebytes() function.

Unfortunately the python function is tailored for the MIME standard (and has no option to configure the number of chars), and the PEM standard is different: It wants 64 chars per line. While most implementations accept arbitrary line lengths, we still should strive to make the output correct. Also there should be a newline at the end.

I had to change the code a bit, and unfortunately it doesn't really look elegant (maybe you have ideas how to improve). I'm now doing the formatting in string form and reconvert back to bytes at the end.