### PR TITLE
Limit number of tries in factoring with d to avoid hang with invalid values

### DIFF
--- a/rsatool.py
+++ b/rsatool.py
@@ -45,7 +45,11 @@ def factor_modulus(n, d, e):
 
     found = False
 
+    tries = 0
     while not found:
+        tries += 1
+        if tries >= 1000:
+            raise ValueError("Factorization/d: no success after 1000 tries")
         i = 1
         a = random.randint(1, n - 1)
 


### PR DESCRIPTION
With the current code, regenerating a key from invalid n/d/e values can hang.

Simple example:
```
#!/usr/bin/python3
from rsatool import rsatool
rsa = rsatool.RSA(n=65537, d=65537, e=65537)
```

To avoid this from happening, there should be a limit in the loop ("while not found:"). This patch stops trying to factor after 1000 tries.
In my experiments, it usually succeeds after 1-2 attempts, so 1000 should be plenty to make sure it does not fail with valid inputs.