### PR TITLE
Prevent d/e values <= 1 to avoid infinite loop

### DIFF
--- a/rsatool.py
+++ b/rsatool.py
@@ -31,6 +31,9 @@ def factor_modulus(n, d, e):
     t = e * d - 1
     s = 0
 
+    if d <= 1 or e <= 1:
+        raise ValueError("d, e can't be <=1")
+
     if 17 != gmpy2.powmod(17, e * d, n):
         raise ValueError("n, d, e don't match")
 


### PR DESCRIPTION
This avoids a potential infinite loop when recovering prime factors from n, d, e.

The loop starting in line 37 can run forever if t is 0. This is the case if d, e are both 1 or -1.

Example:
```
./rsatool.py -n 21 -d 1 -e 1
./rsatool.py -n 21 -d -1 -e -1
```

This PR adds a check for invalid d, e values <=1.

Related, a similar issue in python cryptography: https://github.com/pyca/cryptography/pull/12272